### PR TITLE
fix: notification functionality

### DIFF
--- a/src/input/input.rs
+++ b/src/input/input.rs
@@ -80,14 +80,14 @@ pub fn display_notification(text: String) {
     );
 
     // save cursor position
-    write!(stdout, "{}", cursor::Save).unwrap();
+    stdout.write_all(&"\x1B7".as_bytes()).unwrap();
     stdout.flush().unwrap();
 
     stdout.write_all(&notification.as_bytes()).unwrap();
     stdout.flush().unwrap();
 
     // restore cursor position
-    write!(stdout, "{}", cursor::Restore).unwrap();
+    stdout.write_all(&"\x1B8".as_bytes()).unwrap();
     stdout.flush().unwrap();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use input::input::{read_line, CompletionHelper};
 use menu::menu_list::clear;
 use rustyline::history::MemHistory;
-use rustyline::{Config, CompletionType, Editor};
+use rustyline::{CompletionType, Config, Editor};
 use std::process::{exit, Command};
 use termion::raw::IntoRawMode;
 
@@ -157,7 +157,14 @@ async fn main() {
         let soc_added = handle_new_shell(soc, connected_shells.clone(), None).await;
 
         if soc_added {
-            display_notification(String::from("new shell received!"));
+            let num_shells = connected_shells.lock().await.len();
+            display_notification(format!(
+                "{num_shells} shell{plural} in trap!",
+                plural = match num_shells {
+                    1 => "",
+                    _ => "s",
+                }
+            ));
         }
     }
 }


### PR DESCRIPTION
termion save and restore cursor ansi escapes not working, switched to doing the manually